### PR TITLE
Download RHSM product id certificates

### DIFF
--- a/redhat-upgrade-tool.spec
+++ b/redhat-upgrade-tool.spec
@@ -12,6 +12,7 @@ Source0:        %{name}-%{version}.tar.xz
 # Bug #910326
 Requires:       systemd >= 44-23
 Requires:       grubby
+Requires:       python-rhsm
 
 BuildRequires:  python2-devel
 BuildRequires:  systemd-devel

--- a/redhat_upgrade_tool/commandline.py
+++ b/redhat_upgrade_tool/commandline.py
@@ -20,6 +20,7 @@
 import os, argparse, platform
 
 from . import media
+from . import packagedir
 from .sysprep import reset_boot, remove_boot, remove_cache, misc_cleanup
 from . import _
 
@@ -188,6 +189,15 @@ def VERSION(arg):
         raise argparse.ArgumentTypeError(msg)
 
 def do_cleanup(args):
+    # FIXME: This installs RHSM product certificates in case that
+    # redhat-upgrade-dracut have not installed them.
+    # This may be dropped when new redhat-upgrade-dracut is part of
+    # install images.
+    for cert in filter(lambda fn: fn.endswith('.pem'), os.listdir(packagedir)):
+        old_fn = os.path.join(packagedir, cert)
+        new_fn = '/etc/pki/product/%s' % cert
+        print "Installing product cert %s to %s" % (old_fn, new_fn)
+        os.rename(old_fn, new_fn)
     if not args.skipbootloader:
         print "resetting bootloader config"
         reset_boot()


### PR DESCRIPTION
Hi David, since the yum plugin I was talking about would be used only by redhat-upgrade-tool, I believe it makes sense to simply include the code in redhat-upgrade-tool itself.