### PR TITLE
add check on po_with_problems that has a missing package in the packa…

### DIFF
--- a/redhat_upgrade_tool/download.py
+++ b/redhat_upgrade_tool/download.py
@@ -291,6 +291,9 @@ class UpgradeDownloader(yum.YumBase):
 
         done = set()
         for pkg1, pkg2, err in self.po_with_problems:
+            if pkg1 is None or pkg2 is None:
+                log.error("Empty package information for error %s" % (err))
+                continue
             if (pkg1,pkg2) not in done:
                 problems.append("%s requires %s" % (format_replacement(pkg1),
                                                     format_replacement(pkg2)))


### PR DESCRIPTION
The `po_with_problems` in Yum can contain a None package in the returned package pair. For example,

> `pkg1` is "1:libguestfs-tools-c-1.28.1-1.55.el7.centos.x86_64"
> `pkg2` is None
> `err` is "1:libguestfs-tools-c-1.28.1-1.55.el7.centos.x86_64 requires /usr/bin/vi"

Therefore in the loop of calls to `format_replacement` with the None package would cause

```
finding updates 100% [===================================================================================================]
Traceback (most recent call last):
  File "/usr/bin/redhat-upgrade-tool", line 310, in 
    main(args)
  File "/usr/bin/redhat-upgrade-tool", line 218, in main
    pkgs = download_packages(f)
  File "/usr/bin/redhat-upgrade-tool", line 77, in download_packages
    transprobs = f.describe_transaction_problems()
  File "/usr/lib/python2.6/site-packages/redhat_upgrade_tool/download.py", line 291, in describe_transaction_problems
    format_replacement(pkg2)))
  File "/usr/lib/python2.6/site-packages/redhat_upgrade_tool/download.py", line 279, in format_replacement
    oldpkg, newpkg = find_replacement(po)
  File "/usr/lib/python2.6/site-packages/redhat_upgrade_tool/download.py", line 266, in find_replacement
    for tx in self.tsInfo.getMembers(po.pkgtup):
AttributeError: 'NoneType' object has no attribute 'pkgtup'

```

Looks like other people also encounter this issue: http://linuxsysconfig.com/2014/07/upgrade-to-centos-7/#comment-240575.

I guess the root cause is in Yum, i.e., it returns a None package in a pair. (In fact, I printed the `po_with_problems`, one of the list item seems to be a duplicate but correct data entry). But I'm not sure how to find the problem in yum. This patch simply ignore and logs error when it encounters a problematic data entry. 

> `pkg1` is "1:libguestfs-tools-c-1.28.1-1.55.el7.centos.x86_64"
> `pkg2` is "1:libguestfs-tools-c-1.28.1-1.55.el7.centos.x86_64"
> `err` is "1:libguestfs-tools-c-1.28.1-1.55.el7.centos.x86_64 requires /usr/bin/vi"


